### PR TITLE
Add shutdown to make sure Timer gets terminated

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -171,6 +171,11 @@ class TimeSkill(MycroftSkill):
         self.enclosure.reset()
         self.isClockRunning = False
 
+    def shutdown(self):
+        super(TimeSkill, self).shutdown()
+        if self.timer:
+            self.timer.cancel()
+            self.timer = None
 
 def create_skill():
     return TimeSkill()


### PR DESCRIPTION
====  Tech Notes ====
To make sure no trailing reference to the skill object exist after
shutdown the Timer is canceled and joined if active.