### PR TITLE
Prevent becoming active when showing clock

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -178,7 +178,6 @@ class TimeSkill(MycroftSkill):
         if not dt:
             return
 
-        self.log.debug("********* Time: " + str(dt))
         return nice_time(dt, self.lang, speech=True,
                          use_24hour=self.use_24hour)
 
@@ -216,7 +215,6 @@ class TimeSkill(MycroftSkill):
 
         # draw the time, centered on display
         xoffset = (32 - (4*(len(display_time))-2)) / 2
-        self.log.debug("Offset: "+str(display_time))
         for c in display_time:
             if c in code_dict:
                 self.enclosure.mouth_display(img_code=code_dict[c],


### PR DESCRIPTION
When the clock is being displayed during 'idle' periods, it shouldn't
be considered an active skill.  So now it removes the skill from
active status after drawing to the screen.