### PR TITLE
German language version for date-time added

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -224,6 +224,7 @@ class TimeSkill(MycroftSkill):
             '9': 'EIMBEBMHAA',
         }
 
+        
         # clear screen (draw two blank sections, numbers cover rest)
         if len(display_time) == 4:
             # for 4-character times, 9x8 blank
@@ -239,7 +240,7 @@ class TimeSkill(MycroftSkill):
                                          x=24, refresh=False)
 
         # draw the time, centered on display
-        xoffset = (32-(4*(len(display_time))-2)) / 2
+        xoffset = (32 - (4*(len(display_time))-2)) / 2
         for c in display_time:
             if c in code_dict:
                 self.enclosure.mouth_display(img_code=code_dict[c],

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017, Mycroft AI Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +29,6 @@ from mycroft.util.lang.format_de import nice_time_de, pronounce_ordinal_de
 
 # TODO: This is temporary until nice_time() gets fixed in mycroft-core's
 # next release
-
 def nice_time(dt, lang, speech=True, use_24hour=False, use_ampm=False):
     """
     Format a time to a comfortable human format
@@ -102,7 +100,7 @@ def nice_time(dt, lang, speech=True, use_24hour=False, use_ampm=False):
         elif dt.hour < 13:
             speak = pronounce_number(dt.hour)
         else:
-            speak = pronounce_number(dt.hour - 12)
+            speak = pronounce_number(dt.hour-12)
 
         if dt.minute == 0:
             if not use_ampm:
@@ -241,7 +239,7 @@ class TimeSkill(MycroftSkill):
                                          x=24, refresh=False)
 
         # draw the time, centered on display
-        xoffset = (32 - (4 * (len(display_time)) - 2)) / 2
+        xoffset = (32-(4*(len(display_time))-2)) / 2
         for c in display_time:
             if c in code_dict:
                 self.enclosure.mouth_display(img_code=code_dict[c],


### PR DESCRIPTION
Mycroft can now say date and time in German, if mycroft.conf contains "lang": "de-de".

Test: 
Ask: Welcher Tag ist heute? 
Response: Samstag, der siebte Juli zweitausendachtzehn
Ask: Wieviel Uhr ist es?
Response: vierzehn Uhr achtundzwanzig


Background:
The DateTimeFormat in format.py with a corresponding res/text//de-de/date_time.json might not work for German for now, at least for the pronunciation of minutes and years. This is because in German, a number is not read from left to right. Instead, the last digit is read before the tens, but after the hundreds: 234 becomes zweihundert(200)vier(4)unddreißig(30).  This is already implemented in format_de in pronounce_number_de. Additionally, ordinals (like 1st of April) need to be declined depending on the grammatical case (for example depending on the preposition before the date).