### PR TITLE
Improved Location Parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pytz==2017.2
 tzlocal==1.3
 astral==1.4
+geopy
+timezonefinder


### PR DESCRIPTION
Addresses Issue #12 . geopy and timezonefinder accept inputs of city, city/state, and city/country for better dismbiguation (tested with Portland (Oregon and Maine) and Naples (Italy, Florida)). Astral remains and will process in the event geopy/timezonefinder fails to match a location.