### PR TITLE
fix nice_date using self.lang

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -384,7 +384,7 @@ class TimeSkill(MycroftSkill):
         if not day:
             return  # failed in timezone lookup
 
-        speak = nice_date(day)
+        speak = nice_date(day, lang=self.lang)
         # speak it
         self.speak_dialog("date", {"date": speak})
 


### PR DESCRIPTION
It seems that speaking time didnt use plang parameter. This fixes that.