### PR TITLE
fix german language issue

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,8 @@ import holidays
 import pytz
 import re
 import time
-from astral import geocoder
+from timezonefinder import TimezoneFinder
+import geocoder
 
 import mycroft.audio
 from adapt.intent import IntentBuilder
@@ -99,8 +100,13 @@ class TimeSkill(MycroftSkill):
     def _get_timezone_from_builtins(self, locale):
         try:
             # This handles common city names, like "Dallas" or "Paris"
-            return pytz.timezone(geocoder.lookup(locale, geocoder.database())
-                                         .timezone)
+            # first get the lat / long.
+            g = geocoder.osm(locale)
+            
+            # now look it up
+            tf = TimezoneFinder()
+            timezone = tf.timezone_at(lng=g.lng, lat=g.lat)
+            return pytz.timezone(timezone)
         except Exception:
             pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytz==2017.2
 tzlocal==1.3
-astral>=2.1
+timezonefinder
+geocoder
 holidays

--- a/vocab/de-de/date.future.weekend.intent
+++ b/vocab/de-de/date.future.weekend.intent
@@ -1,3 +1,3 @@
-(Was sind die|) Tage (für |) (dieses | nächste) Wochenende
-Was (Datum ist | Datum ist) (dieses | nächste) Wochenende
-was (ist das Datum | sind die Daten) (für |) (dieses | nächste) Wochenende
+(Was sind die|) Tage (für |) (dieses | nächstes) Wochenende
+Was (für ein | )Datum ist (dieses | nächstes) Wochenende
+was (ist das Datum | sind die Daten) (für |) (dieses | nächstes) Wochenende

--- a/vocab/de-de/date.future.weekend.intent
+++ b/vocab/de-de/date.future.weekend.intent
@@ -1,3 +1,3 @@
-Was (sind die |) Tage (für |) | Tag ist) (dieses | nächste) Wochenende
+(Was sind die|) Tage (für |) (dieses | nächste) Wochenende
 Was (Datum ist | Datum ist) (dieses | nächste) Wochenende
 was (ist das Datum | sind die Daten) (für |) (dieses | nächste) Wochenende

--- a/vocab/de-de/what.time.is.it.intent
+++ b/vocab/de-de/what.time.is.it.intent
@@ -1,3 +1,5 @@
-(das |) (Uhrzeit | Uhr) ((rechts |) jetzt |) (bitte |)
+(die |) (uhrzeit | uhr) (jetzt | ) (bitte |)
 Hast du die (aktuelle|) Uhrzeit
-aktuelle Zeit
+aktuelle (uhrzeit | zeit)
+Wie spät ist es
+sag mir die (uhrzeit| zeit)


### PR DESCRIPTION
Fixes #80 
Also adds two lines to what.time.is.it intent which are very commonly used in German. 
(As of now, mycroft will redirect the question of what time it is in German to wolfram alpha, which answers, but doesn't involve this skill)