### PR TITLE
fix geocoder issue

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,8 @@ import holidays
 import pytz
 import re
 import time
-from astral import geocoder
+from timezonefinder import TimezoneFinder
+import geocoder
 
 import mycroft.audio
 from adapt.intent import IntentBuilder
@@ -99,8 +100,13 @@ class TimeSkill(MycroftSkill):
     def _get_timezone_from_builtins(self, locale):
         try:
             # This handles common city names, like "Dallas" or "Paris"
-            return pytz.timezone(geocoder.lookup(locale, geocoder.database())
-                                         .timezone)
+            # first get the lat / long.
+            g = geocoder.osm(locale)
+            
+            # now look it up
+            tf = TimezoneFinder()
+            timezone = tf.timezone_at(lng=g.lng, lat=g.lat)
+            return pytz.timezone(timezone)
         except Exception:
             pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytz==2017.2
 tzlocal==1.3
-astral>=2.1
+timezonefinder
+geocoder
 holidays


### PR DESCRIPTION
This fixes #82 

**Background**
Astral removed its geocoder feature in its current release. Due to the removal, this skill won't load.

Fixing astral to the version 2.1 won't help. Astral geocoder uses googles API. Google's map API changed to a required [API key](https://developers.google.com/maps/gmp-get-started#enable-api-sdk). 

This PR now uses [geocoder](https://github.com/DenisCarriere/geocoder) and [TimezoneFinder](https://pypi.org/project/timezonefinder) to utilize the same function, but uses [OpenStreetMaps](https://geocoder.readthedocs.io/providers/OpenStreetMap.html).

Unfortunately, there is no direct information concerning the timezone from geocoder. So the second package is necessary, which will convert the longitude and latitude information to a timezone. 

No user interaction or change should be necessary, and no API key needs to be added.
