### PR TITLE
Catch utterance in future intent without datetime

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -405,8 +405,11 @@ class TimeSkill(MycroftSkill):
         utt = normalize(message.data.get('utterance', "").lower())
         extract = extract_datetime(utt)
         if extract:
-            dt = extract[0]
-            utt = extract[1]
+            dt, utt = extract
+        else:
+            self.handle_query_time(message)
+            return
+
         location = self._extract_location(utt)
         future_time = self.get_spoken_current_time(location, dt, True)
         if not future_time:

--- a/test/behave/time.feature
+++ b/test/behave/time.feature
@@ -54,6 +54,7 @@ Feature: Date Time Skill Time functionality
     | what is the time in a location |
     | what's the time in paris |
     | what's the time in london |
+    | time in Toronto |
 
   @xfail
   # jira MS-100 https://mycroft.atlassian.net/browse/MS-100


### PR DESCRIPTION
Caught this while reviewing other PR's.

If an utterance gets matched with the future time intent but has no datetime to extract then it failed as `dt` was not assigned. 

Future work should be done to improve intent matching but this catches those instances and redirects to the appropriate handler. They are matching as the user may say "time in 8 hours"

As per added test:
- Ask "time in Paris"