### PR TITLE
Remove specific intent handler from old test

### DIFF
--- a/test/intent/011.whats-the-relative-date-past.intent.json
+++ b/test/intent/011.whats-the-relative-date-past.intent.json
@@ -1,9 +1,7 @@
 {
   "utterance": "what was the date last tuesday",
-  "intent_type": "handle_query_relative_date",
   "intent": {
-    "RelativeDay": "tuesday",
-    "Query": "what"
+    "RelativeDay": "tuesday"
   },
   "expected_dialog": "date.relative.past"
 }


### PR DESCRIPTION
There are multiple possible intent handlers registered that can
be triggered by this utterance. The test still verifies that the
correct entities are extracted, correct dialog file is used, and
that the response is for Tuesday in the past.