### PR TITLE
Change Time UI layouts for horizontal mode and vertical mode and fix margins

### DIFF
--- a/ui/time.qml
+++ b/ui/time.qml
@@ -2,16 +2,19 @@ import QtQuick.Layouts 1.4
 import QtQuick 2.4
 import QtQuick.Controls 2.0
 import org.kde.kirigami 2.4 as Kirigami
-
+import QtQuick.Window 2.3
 import Mycroft 1.0 as Mycroft
 
 Mycroft.Delegate {
     id: timeRoot
     
-    ColumnLayout {
+    property bool horizontalMode: timeRoot.width > timeRoot.height ? 1 : 0
+    
+    GridLayout {
         id: grid
         anchors.fill: parent
-        spacing: Kirigami.Units.largeSpacing
+        anchors.margins: parent.height * 0.10
+        columns: horizontalMode ? 3 : 1
 
         Item {
             Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
@@ -27,7 +30,7 @@ Mycroft.Delegate {
                 font.family: "Noto Sans"
                 font.bold: true
                 font.weight: Font.Bold
-                font.pixelSize: height
+                font.pixelSize: horizontalMode ? parent.width : parent.height
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 text: sessionData.time_string.split(":")[0]
@@ -35,6 +38,31 @@ Mycroft.Delegate {
                 renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
             }
         }
+        
+        Item {
+            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+            Layout.preferredWidth: parent.width / 6
+            Layout.fillHeight: true
+            Layout.margins: Kirigami.Units.smallSpacing
+            visible: horizontalMode ? 1 : 0
+            enabled: horizontalMode ? 1 : 0
+            
+            Label {
+                id: dots
+                width: parent.width
+                height: parent.height
+                font.capitalization: Font.AllUppercase
+                font.family: "Noto Sans"
+                font.bold: true
+                font.weight: Font.Normal
+                font.pixelSize: width
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: ":"
+                color: "white"
+                renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
+            }
+        }        
         
         Item {
             Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
@@ -50,7 +78,7 @@ Mycroft.Delegate {
                 font.family: "Noto Sans"
                 font.bold: false
                 font.weight: Font.Normal
-                font.pixelSize: height
+                font.pixelSize: horizontalMode ? parent.width : parent.height
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 text: sessionData.time_string.split(":")[1]

--- a/ui/time.qml
+++ b/ui/time.qml
@@ -74,7 +74,6 @@ Mycroft.Delegate {
                     height: parent.height
                     visible: horizontalMode ? 1 : 0
                     enabled: horizontalMode ? 1 : 0
-                    color: "transparent"
                 }
 
                 Item {

--- a/ui/time.qml
+++ b/ui/time.qml
@@ -95,8 +95,8 @@ Mycroft.Delegate {
                         height: parent.height
                         font.capitalization: Font.AllUppercase
                         font.family: "Noto Sans"
-                        font.bold: false
-                        font.weight: Font.Normal
+                        font.bold: true
+                        font.weight: Font.Bold
                         font.pixelSize: horizontalMode ? timeRoot.horizontalFontWidth : parent.height
                         horizontalAlignment: horizontalMode ? Text.AlignLeft : Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter

--- a/ui/time.qml
+++ b/ui/time.qml
@@ -17,7 +17,7 @@ Mycroft.Delegate {
         columns: horizontalMode ? 3 : 1
 
         Item {
-            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+            Layout.alignment: horizontalMode && hour.text.length > 1 ? Qt.AlignTop | Qt.AlignRight : Qt.AlignTop | Qt.AlignHCenter
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.margins: Kirigami.Units.smallSpacing
@@ -31,11 +31,20 @@ Mycroft.Delegate {
                 font.bold: true
                 font.weight: Font.Bold
                 font.pixelSize: horizontalMode ? parent.width : parent.height
-                horizontalAlignment: Text.AlignHCenter
+                horizontalAlignment: horizontalMode ? Text.AlignRight : Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
-                text: sessionData.time_string.split(":")[0]
                 color: "white"
                 renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
+                
+                Component.onCompleted: {
+                    var setHour = sessionData.time_string.split(":")[0]
+                    if(setHour.length == 1 && horizontalMode) {
+                        setHour = "  " + setHour
+                        hour.text = setHour
+                    } else {
+                        hour.text = setHour
+                    }
+                }
             }
         }
         
@@ -65,7 +74,7 @@ Mycroft.Delegate {
         }        
         
         Item {
-            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+            Layout.alignment: horizontalMode && minute.text.length > 1 ? Qt.AlignTop | Qt.AlignLeft : Qt.AlignTop | Qt.AlignHCenter
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.margins: Kirigami.Units.smallSpacing
@@ -79,11 +88,20 @@ Mycroft.Delegate {
                 font.bold: false
                 font.weight: Font.Normal
                 font.pixelSize: horizontalMode ? parent.width : parent.height
-                horizontalAlignment: Text.AlignHCenter
+                horizontalAlignment: horizontalMode ? Text.AlignLeft : Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
-                text: sessionData.time_string.split(":")[1]
                 color: "#22A7F0"
                 renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
+                
+                Component.onCompleted: {
+                    var setMin = sessionData.time_string.split(":")[1]
+                    if(setMin.length == 1 && horizontalMode) {
+                        setMin = setMin + "  "
+                        minute.text = setMin
+                    } else {
+                        minute.text = setMin
+                    }
+                }
             }
         }
     }

--- a/ui/time.qml
+++ b/ui/time.qml
@@ -30,10 +30,11 @@ Mycroft.Delegate {
         anchors.fill: parent
         anchors.margins: horizontalMode ? timeRoot.height * 0.30 : timeRoot.height * 0.15
         
-        Item {
+        Rectangle {
             id: rectGrid
             implicitWidth: parent.width
             implicitHeight: parent.height
+            color: "transparent"
 
             GridLayout {
                 id: gridtype
@@ -41,10 +42,11 @@ Mycroft.Delegate {
                 anchors.centerIn: parent
                 columns: horizontalMode ? 3 : 1
 
-                Item {
+                Rectangle {
                     Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
                     Layout.preferredWidth: horizontalMode && hourText.length == 1 ? timeRoot.horizontalFontWidth / 2 : timeRoot.horizontalFontWidth
                     Layout.fillHeight: true
+                    color: "transparent"
 
                     Label {
                         id: hour
@@ -54,14 +56,20 @@ Mycroft.Delegate {
                         font.family: "Noto Sans"
                         font.bold: true
                         font.weight: Font.Bold
-                        font.pixelSize: horizontalMode ? timeRoot.horizontalFontWidth : parent.height * 1.1
+                        font.pixelSize: horizontalMode ? timeRoot.horizontalFontWidth : parent.height
                         horizontalAlignment: horizontalMode ? Text.AlignRight : Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                         color: "white"
                         renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
 
                         Component.onCompleted: {
-                            hour.text = hourText
+                            var setHour
+                            if(hourText.length == 1 && horizontalMode) {
+                                setHour = setHour + "  "
+                                hour.text = setHour
+                            } else {
+                                hour.text = hourText
+                            }
                         }
                     }
                 }
@@ -76,9 +84,10 @@ Mycroft.Delegate {
                     enabled: horizontalMode ? 1 : 0
                 }
 
-                Item {
+                Rectangle {
                     Layout.preferredWidth: timeRoot.horizontalFontWidth
                     Layout.fillHeight: true
+                    color: "transparent"
 
                     Label {
                         id: minute
@@ -88,14 +97,20 @@ Mycroft.Delegate {
                         font.family: "Noto Sans"
                         font.bold: false
                         font.weight: Font.Normal
-                        font.pixelSize: horizontalMode ? timeRoot.horizontalFontWidth : parent.height * 1.1
+                        font.pixelSize: horizontalMode ? timeRoot.horizontalFontWidth : parent.height
                         horizontalAlignment: horizontalMode ? Text.AlignLeft : Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                         color: "#22A7F0"
                         renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
 
                         Component.onCompleted: {
-                            minute.text = minuteText
+                            var setMin
+                            if(minuteText.length == 1 && horizontalMode) {
+                                setMin = setMin + "  "
+                                minute.text = setMin
+                            } else {
+                                minute.text = minuteText
+                            }
                         }
                     }
                 }

--- a/ui/time.qml
+++ b/ui/time.qml
@@ -8,98 +8,96 @@ import Mycroft 1.0 as Mycroft
 Mycroft.Delegate {
     id: timeRoot
     
-    property bool horizontalMode: timeRoot.width > timeRoot.height ? 1 : 0
+    leftPadding: 0
+    rightPadding: 0
+    bottomPadding: 0
+    topPadding: 0
     
-    GridLayout {
-        id: grid
+    property bool horizontalMode: timeRoot.width > timeRoot.height ? 1 : 0
+    property var horizontalFontWidth: horizontalMode ? rectGrid.implicitWidth / 2 - colons.implicitWidth : rectGrid.implicitWidth / 2
+    property var hourText: sessionData.time_string.split(":")[0]
+    property var minuteText: sessionData.time_string.split(":")[1]
+    
+    onHourTextChanged: {
+        hour.text = hourText
+    }
+    
+    onMinuteTextChanged: {
+        minute.text = minuteText
+    }
+    
+    Item {
         anchors.fill: parent
-        anchors.margins: parent.height * 0.10
-        columns: horizontalMode ? 3 : 1
-
+        anchors.margins: horizontalMode ? timeRoot.height * 0.30 : timeRoot.height * 0.15
+        
         Item {
-            Layout.alignment: horizontalMode && hour.text.length > 1 ? Qt.AlignTop | Qt.AlignRight : Qt.AlignTop | Qt.AlignHCenter
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.margins: Kirigami.Units.smallSpacing
-            
-            Label {
-                id: hour
-                width: parent.width
+            id: rectGrid
+            implicitWidth: parent.width
+            implicitHeight: parent.height
+
+            GridLayout {
+                id: gridtype
                 height: parent.height
-                font.capitalization: Font.AllUppercase
-                font.family: "Noto Sans"
-                font.bold: true
-                font.weight: Font.Bold
-                font.pixelSize: horizontalMode ? parent.width : parent.height
-                horizontalAlignment: horizontalMode ? Text.AlignRight : Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                color: "white"
-                renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
-                
-                Component.onCompleted: {
-                    var setHour = sessionData.time_string.split(":")[0]
-                    if(setHour.length == 1 && horizontalMode) {
-                        setHour = "  " + setHour
-                        hour.text = setHour
-                    } else {
-                        hour.text = setHour
+                anchors.centerIn: parent
+                columns: horizontalMode ? 3 : 1
+
+                Item {
+                    Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                    Layout.preferredWidth: horizontalMode && hourText.length == 1 ? timeRoot.horizontalFontWidth / 2 : timeRoot.horizontalFontWidth
+                    Layout.fillHeight: true
+
+                    Label {
+                        id: hour
+                        width: parent.width
+                        height: parent.height
+                        font.capitalization: Font.AllUppercase
+                        font.family: "Noto Sans"
+                        font.bold: true
+                        font.weight: Font.Bold
+                        font.pixelSize: horizontalMode ? timeRoot.horizontalFontWidth : parent.height * 1.1
+                        horizontalAlignment: horizontalMode ? Text.AlignRight : Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        color: "white"
+                        renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
+
+                        Component.onCompleted: {
+                            hour.text = hourText
+                        }
                     }
                 }
-            }
-        }
-        
-        Item {
-            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
-            Layout.preferredWidth: parent.width / 6
-            Layout.fillHeight: true
-            Layout.margins: Kirigami.Units.smallSpacing
-            visible: horizontalMode ? 1 : 0
-            enabled: horizontalMode ? 1 : 0
-            
-            Label {
-                id: dots
-                width: parent.width
-                height: parent.height
-                font.capitalization: Font.AllUppercase
-                font.family: "Noto Sans"
-                font.bold: true
-                font.weight: Font.Normal
-                font.pixelSize: width
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: ":"
-                color: "white"
-                renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
-            }
-        }        
-        
-        Item {
-            Layout.alignment: horizontalMode && minute.text.length > 1 ? Qt.AlignTop | Qt.AlignLeft : Qt.AlignTop | Qt.AlignHCenter
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.margins: Kirigami.Units.smallSpacing
-            
-            Label {
-                id: minute
-                width: parent.width
-                height: parent.height
-                font.capitalization: Font.AllUppercase
-                font.family: "Noto Sans"
-                font.bold: false
-                font.weight: Font.Normal
-                font.pixelSize: horizontalMode ? parent.width : parent.height
-                horizontalAlignment: horizontalMode ? Text.AlignLeft : Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                color: "#22A7F0"
-                renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
-                
-                Component.onCompleted: {
-                    var setMin = sessionData.time_string.split(":")[1]
-                    if(setMin.length == 1 && horizontalMode) {
-                        setMin = setMin + "  "
-                        minute.text = setMin
-                    } else {
-                        minute.text = setMin
+
+                Item {
+                    id: colons
+                    Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+                    Layout.fillHeight: true
+                    Layout.preferredWidth: parent.width * 0.10
+                    height: parent.height
+                    visible: horizontalMode ? 1 : 0
+                    enabled: horizontalMode ? 1 : 0
+                    color: "transparent"
+                }
+
+                Item {
+                    Layout.preferredWidth: timeRoot.horizontalFontWidth
+                    Layout.fillHeight: true
+
+                    Label {
+                        id: minute
+                        width: parent.width
+                        height: parent.height
+                        font.capitalization: Font.AllUppercase
+                        font.family: "Noto Sans"
+                        font.bold: false
+                        font.weight: Font.Normal
+                        font.pixelSize: horizontalMode ? timeRoot.horizontalFontWidth : parent.height * 1.1
+                        horizontalAlignment: horizontalMode ? Text.AlignLeft : Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        color: "#22A7F0"
+                        renderType: height > 40 ? Text.QtRendering : (Screen.devicePixelRatio % 1 !== 0 ? Text.QtRendering : Text.NativeRendering)
+
+                        Component.onCompleted: {
+                            minute.text = minuteText
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes margins and auto changes layout responsively as suggested by @dschweppe on https://github.com/MycroftAI/skill-date-time/pull/92 to have time side by side in horizontal display and maintains vertical layout for vertical display 

- Preview - Width: 800 Height: 480 [horizontal]
![date-time-800w-480h](https://user-images.githubusercontent.com/19663666/97269013-d7b0b880-1852-11eb-8ae6-5f29c40c498d.png)

- Preview - Width: 480 Height: 800 [vertical]
![date-time-480w-800h](https://user-images.githubusercontent.com/19663666/97269048-e13a2080-1852-11eb-8b0a-c024dd79da9f.png)
