### PR TITLE
Fix #103 timezone lookup fails for some TZ settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -99,17 +99,18 @@ class TimeSkill(MycroftSkill):
         return self.config_core.get('time_format') == 'full'
 
     def _get_timezone_from_builtins(self, locale):
-        try:
-            # This handles common city names, like "Dallas" or "Paris"
-            # first get the lat / long.
-            g = geocoder.osm(locale)
-            
-            # now look it up
-            tf = TimezoneFinder()
-            timezone = tf.timezone_at(lng=g.lng, lat=g.lat)
-            return pytz.timezone(timezone)
-        except Exception:
-            pass
+        if "/" not in locale:
+            try:
+                # This handles common city names, like "Dallas" or "Paris"
+                # first get the lat / long.
+                g = geocoder.osm(locale)
+
+                # now look it up
+                tf = TimezoneFinder()
+                timezone = tf.timezone_at(lng=g.lng, lat=g.lat)
+                return pytz.timezone(timezone)
+            except Exception:
+                pass
 
         try:
             # This handles codes like "America/Los_Angeles"


### PR DESCRIPTION
When a TZ is set it can be in the form "Europe/Dublin", these are
not intended to be handled by the first try block. This conditional
assumes that any string with a "/" is not a standard place name.

Fixes #103 
Thanks to @dmcnamara-eng for reporting this and suggesting the fix.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
VK tests still passing
Can manually set TZ in Device settings.
