### PR TITLE
Add build date to home screen on development units

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,9 +14,11 @@
 
 import datetime
 import holidays
+import json
 import pytz
 import re
 import time
+from os.path import isfile
 from timezonefinder import TimezoneFinder
 import geocoder
 
@@ -92,12 +94,19 @@ class TimeSkill(MycroftSkill):
         self.gui['weekday_string'] = self.get_weekday()
         self.gui['month_string'] = self.get_month_date()
         self.gui['year_string'] = self.get_year()
-        timestamp_file = "build-timestamp.txt"
-        if (self.config_core["enclosure"].get("development_device")
-            and self.file_system.exists(timestamp_file)):
-            with self.file_system.open(timestamp_file, "r") as timestamp:
-                self.gui['build_date'] = timestamp.read()
+        self.gui['build_date'] = self.build_info.get('build_date', '')
         self.gui.show_page('idle.qml')
+
+    @property
+    def build_info(self):
+        """The /etc/mycroft/build-info.json file as a Dict."""
+        data = {}
+        filename = "/etc/mycroft/build-info.json"
+        if (self.config_core["enclosure"].get("development_device")
+            and isfile(filename)):
+            with open(filename, 'r') as build_info:
+                data = json.loads(build_info.read())
+        return data
 
     @property
     def use_24hour(self):

--- a/__init__.py
+++ b/__init__.py
@@ -92,6 +92,11 @@ class TimeSkill(MycroftSkill):
         self.gui['weekday_string'] = self.get_weekday()
         self.gui['month_string'] = self.get_month_date()
         self.gui['year_string'] = self.get_year()
+        timestamp_file = "build-timestamp.txt"
+        if (self.config_core["enclosure"].get("development_device")
+            and self.file_system.exists(timestamp_file)):
+            with self.file_system.open(timestamp_file, "r") as timestamp:
+                self.gui['build_date'] = timestamp.read()
         self.gui.show_page('idle.qml')
 
     @property

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ import json
 import pytz
 import re
 import time
-from os.path import isfile
+from pathlib import Path
 from timezonefinder import TimezoneFinder
 import geocoder
 
@@ -103,7 +103,7 @@ class TimeSkill(MycroftSkill):
         data = {}
         filename = "/etc/mycroft/build-info.json"
         if (self.config_core["enclosure"].get("development_device")
-            and isfile(filename)):
+            and Path(filename).is_file()):
             with open(filename, 'r') as build_info:
                 data = json.loads(build_info.read())
         return data

--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -56,4 +56,19 @@ Mycroft.Delegate {
             color: "white"
         }
     }
+    Label {
+        id: buildDate
+        visible: sessionDate.build_date === "" ? 1 : 0
+        enabled: sessionData.build_date === "" ? 1 : 0
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 20
+        font.pixelSize: 16
+        wrapMode: Text.WordWrap
+        font.family: "Noto Sans Display"
+        lineHeight: 0.6
+        text: sessionData.build_date
+        color: "white"
+    }
+
 }

--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -58,7 +58,7 @@ Mycroft.Delegate {
     }
     Label {
         id: buildDate
-        visible: sessionDate.build_date === "" ? 1 : 0
+        visible: sessionData.build_date === "" ? 1 : 0
         enabled: sessionData.build_date === "" ? 1 : 0
         anchors.right: parent.right
         anchors.bottom: parent.bottom

--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -58,12 +58,12 @@ Mycroft.Delegate {
     }
     Label {
         id: buildDate
-        visible: sessionData.build_date === "" ? 1 : 0
-        enabled: sessionData.build_date === "" ? 1 : 0
-        anchors.right: parent.right
+        visible: sessionData.build_date === "" ? 0 : 1
+        enabled: sessionData.build_date === "" ? 0 : 1
+        anchors.left: parent.left
         anchors.bottom: parent.bottom
         anchors.margins: 20
-        font.pixelSize: 16
+        font.pixelSize: 20
         wrapMode: Text.WordWrap
         font.family: "Noto Sans Display"
         lineHeight: 0.6


### PR DESCRIPTION
#### Description
This adds a small timestamp to the lower right corner of the Home Screen if a device reports itself as a development unit and has the expected `build-info.json` file. This file should be generated at build time and placed in `/etc/mycroft/build-info.json`

The purpose of this is to help developers quickly know which version of their build is currently running and whether it has changed. Additional information will be provided by voice commands in other Skills.

The file is in JSON format allowing it to be extended over time. It can contain any relevant build information but currently only has a `build_date` that is the timestamp of the build.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
To test, add the following to your mycroft.conf:
```json
{
  # existing config,
  "enclosure": {
    "development_device": true
  }
}
```
and add a file to the above location containing something like:
```json
{
  "build_date": "Hello World"
}
```