### PR TITLE
Add text outlines for better legibility

### DIFF
--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -26,6 +26,7 @@ Mycroft.Delegate {
             color: "white"
             lineHeight: 0.6
             text: sessionData.time_string.replace(":", "꞉")
+            style: Text.Outline; styleColor: "black"
         }
         Item {
             height: Kirigami.Units.largeSpacing * 5
@@ -40,6 +41,7 @@ Mycroft.Delegate {
             lineHeight: 0.6
             text: sessionData.weekday_string
             color: "white"
+            style: Text.Outline; styleColor: "black"
         }
         Item {
             height: Kirigami.Units.largeSpacing * 3
@@ -54,6 +56,7 @@ Mycroft.Delegate {
             lineHeight: 0.6
             text: sessionData.month_string
             color: "white"
+            style: Text.Outline; styleColor: "black"
         }
     }
     Label {


### PR DESCRIPTION
#### Description

Adds black outline to the white text in the date-time idle screen.  The current idle screen has a fairly light colored background, and further refinements might change the background or make it user-customizable.  When drawing text over arbitrary images, it's wise to give the text an outline so that if the text color too closely matches the background color the text is still legible because the shape of the characters can be discerned from the outline 

#### Type of PR

- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements
- [X] Design tweaks

#### Testing

Does the text now have an outline?

#### Documentation

The UI guidelines could either document good principles for design when using text over images or alternatively link to some guide that does so, perhaps something like https://css-tricks.com/design-considerations-text-images/ which explicitly says only dark images should be used, or in the case of lighter color images, a drop-shadow should be used.
