### PR TITLE
Fix for date not changing on GUI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -346,6 +346,8 @@ class TimeSkill(MycroftSkill):
         self.gui['time_string'] = self.get_display_current_time()
         self.gui['date_string'] = self.get_display_date()
         self.gui['ampm_string'] = ''  # TODO
+        self.gui['weekday_string'] = self.get_weekday()
+        self.gui['month_string'] = self.get_month_date()
 
         if self.settings.get("show_time", False):
             # user requested display of time while idle


### PR DESCRIPTION
#### Description
Mark 2 Devkits have an idle screen displaying the date and time.  As the days pass, the date on the screen does not change.

#### Type of PR
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Watch your device with a screen as the clock tolls midnight.  Or just check the date is right each morning.

#### Documentation
N/A
