### PR TITLE
Switch ambiguous vocab to Padatious intent

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -72,6 +72,7 @@ class TimeSkill(MycroftSkill):
                                            now.hour, now.minute) +
                          datetime.timedelta(seconds=60))
         self.schedule_repeating_event(self.update_display, callback_time, 10)
+        self.register_entity_file("RelativeDay.entity")
 
     # TODO:19.08 Moved to MycroftSkill
     @property
@@ -561,20 +562,16 @@ class TimeSkill(MycroftSkill):
     def handle_day_for_date(self, message):
         self.handle_query_date(message, response_type="relative")
 
-    @intent_handler(IntentBuilder("").require("Query").require("RelativeDay")
-                                     .optionally("Date"))
+    @intent_handler(IntentBuilder("").require("Date").require("RelativeDay").optionally("Query"))
     def handle_query_relative_date(self, message):
         if self.voc_match(message.data.get('utterance', ""), 'Today'):
             self.handle_query_date(message, response_type="simple")
         else:
             self.handle_query_date(message, response_type="relative")
 
-    @intent_handler(IntentBuilder("").require("RelativeDay").require("Date"))
-    def handle_query_relative_date_alt(self, message):
-        if self.voc_match(message.data.get('utterance', ""), 'Today'):
-            self.handle_query_date(message, response_type="simple")
-        else:
-            self.handle_query_date(message, response_type="relative")
+    @intent_handler("what.is.the.date.on.intent")
+    def handle_query_relative_date_padatious(self, message):
+        self.handle_query_relative_date(message)
 
     @intent_handler("date.future.weekend.intent")
     def handle_date_future_weekend(self, message):

--- a/test/behave/date.feature
+++ b/test/behave/date.feature
@@ -1,7 +1,9 @@
 Feature: Date Time Skill Date functionality
 
-  Scenario Outline: what's the date
+  Background: English speaking user
     Given an english speaking user
+
+  Scenario Outline: what's the date
      When the user says "<what's the date>"
      Then "mycroft-date-time" should reply with dialog from "date.dialog"
 
@@ -25,7 +27,6 @@ Feature: Date Time Skill Date functionality
     | what is the day |
 
   Scenario Outline: what is the date a number of days in the future
-    Given an english speaking user
      When the user says "<what's the date in 2 days>"
      Then "mycroft-date-time" should reply with dialog from "date.dialog"
 
@@ -37,7 +38,6 @@ Feature: Date Time Skill Date functionality
     | what is the date 5 days from today |
 
   Scenario Outline: what was the date a number of days in the past
-    Given an english speaking user
      When the user says "<what was the date 2 days ago>"
      Then "mycroft-date-time" should reply with dialog from "date.dialog"
 
@@ -49,7 +49,6 @@ Feature: Date Time Skill Date functionality
     | what was the date 5 days ago |
 
   Scenario Outline: when is a date in the future
-    Given an english speaking user
      When the user says "<what day is future date>"
      Then "mycroft-date-time" should reply with dialog from "date.relative.future.dialog"
 
@@ -66,7 +65,6 @@ Feature: Date Time Skill Date functionality
   @xfail
   # Jira 103 https://mycroft.atlassian.net/browse/MS-103
   Scenario Outline: Failing when is a date in the future
-    Given an english speaking user
      When the user says "<what day is future date>"
      Then "mycroft-date-time" should reply with dialog from "date.relative.future.dialog"
 
@@ -76,7 +74,6 @@ Feature: Date Time Skill Date functionality
     | what day is June 30th |
 
   Scenario Outline: when is a date in the past
-    Given an english speaking user
      When the user says "<what day was it november 1st 1953>"
      Then "mycroft-date-time" should reply with dialog from "date.relative.past.dialog"
 
@@ -90,7 +87,6 @@ Feature: Date Time Skill Date functionality
   @xfail
   # Jira 104 https://mycroft.atlassian.net/browse/MS-105
   Scenario Outline: when is a holiday
-    Given an english speaking user
      When the user says "<when is new year's day>"
      Then "mycroft-date-time" should reply with dialog from "date.dialog"
 
@@ -107,7 +103,6 @@ Feature: Date Time Skill Date functionality
     | when is ramadan 2020 |
 
   Scenario Outline: what is the date next weekend
-    Given an english speaking user
      When the user says "<what is the date next weekend>"
      Then "mycroft-date-time" should reply with dialog from "date.future.weekend.dialog"
 
@@ -118,7 +113,6 @@ Feature: Date Time Skill Date functionality
      | what is the date next weekend |
 
   Scenario Outline: what was the date last weekend
-    Given an english speaking user
      When the user says "<what was the date last weekend>"
      Then "mycroft-date-time" should reply with dialog from "date.last.weekend.dialog"
 
@@ -130,7 +124,6 @@ Feature: Date Time Skill Date functionality
   @xfail
   # Jira 106 https://mycroft.atlassian.net/browse/MS-106
   Scenario Outline: Failing what was the date last weekend
-    Given an english speaking user
      When the user says "<what was the date last weekend>"
      Then "mycroft-date-time" should reply with dialog from "date.last.weekend.dialog"
 
@@ -141,7 +134,6 @@ Feature: Date Time Skill Date functionality
   @xfail
   # Jira 107 https://mycroft.atlassian.net/browse/MS-107
   Scenario Outline: when is the next leap year
-    Given an english speaking user
      When the user says "<when is the next leap year>"
      Then "mycroft-date-time" should reply with dialog from "next.leap.year.dialog"
 
@@ -149,3 +141,16 @@ Feature: Date Time Skill Date functionality
     | when is the next leap year |
     | what year is the next leap year |
     | when is leap year |
+
+  Scenario Outline: Questions that should not trigger this Skill
+     When the user says "<unrelated utterance>"
+     Then "mycroft-date-time" should not reply
+
+  Examples: unrelated utterance
+    | unrelated utterance |
+    | what is the weather on Tuesday |
+    | check tomorrow |
+    | tell me about the weekend |
+    | weather you agree or not |
+    | what is christmas day |
+    | what is ham |

--- a/vocab/en-us/RelativeDay.entity
+++ b/vocab/en-us/RelativeDay.entity
@@ -1,0 +1,16 @@
+today
+todays
+today's
+tomorrow
+tomorrows
+tomorrow's
+yesterday
+yesterdays
+yesterday's
+monday
+tuesday
+wednesday
+thursday
+friday
+saturday
+sunday

--- a/vocab/en-us/what.is.the.date.on.intent
+++ b/vocab/en-us/what.is.the.date.on.intent
@@ -1,0 +1,1 @@
+what is {RelativeDay}


### PR DESCRIPTION
#### Description
The existing Adapt intent was matching anything that contained a query and a relative day term - eg "what is weather tomorrow"
would return a 0.5 confidence for both Weather and DateTime.

This still catches simple utterances like "what is tomorrow", but requires Date vocab to match against longer variations.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [x] Test improvements

#### Testing
VK Tests updated