### PR TITLE
Refactor date ui to use card delegate and mycroft units

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -666,7 +666,13 @@ class TimeSkill(MycroftSkill):
         self.gui.clear()
         self.gui['date_string'] = self.get_display_date(day, location)
         self.gui['weekday_string'] = self.get_weekday(day, location)
-        self.gui['month_string'] = self.get_month_date(day, location)
+        month_string = self.get_month_date(day, location).split(" ")
+        if self.config_core.get('date_format') == 'MDY':
+            self.gui['day_string'] = month_string[1]
+            self.gui['month_string'] = month_string[0]
+        else:
+            self.gui['day_string'] = month_string[0]
+            self.gui['month_string'] = month_string[1]
         self.gui['year_string'] = self.get_year(day, location)
         self.gui.show_page('date.qml')
 

--- a/ui/date.qml
+++ b/ui/date.qml
@@ -2,73 +2,99 @@ import QtQuick.Layouts 1.4
 import QtQuick 2.4
 import QtQuick.Controls 2.0
 import org.kde.kirigami 2.4 as Kirigami
-
 import Mycroft 1.0 as Mycroft
+import QtGraphicalEffects 1.0
 
-Mycroft.Delegate {
-    skillBackgroundColorOverlay: Qt.rgba(0, 0, 0, 1)
-    
+Mycroft.CardDelegate {
+    id: dateRoot
+    topInset: Mycroft.Units.gridUnit / 2
+    bottomInset: Mycroft.Units.gridUnit / 2
+
     ColumnLayout {
         id: grid
-        Layout.fillWidth: true
-        anchors.centerIn: parent
+        anchors.fill: parent
+        spacing: 0
 
         /* Put the day of the week at the top of the screen */
-        Label {
-            id: weekday
-            Layout.alignment: Qt.AlignHCenter
-            font.pixelSize: 65
-            wrapMode: Text.WordWrap
-            renderType: Text.NativeRendering
-            font.family: "Noto Sans Display"
-            font.styleName: "Black"
-            font.capitalization: Font.AllUppercase
-            text: sessionData.weekday_string
-            color: "white"
+        Item { 
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
+            Layout.fillWidth: true
+            Layout.preferredHeight: parent.height / 6
+            
+            Label {
+                id: weekday
+                anchors.centerIn: parent
+                font.pixelSize: parent.height
+                wrapMode: Text.WordWrap
+                renderType: Text.NativeRendering
+                font.family: "Noto Sans Display"
+                font.styleName: "Black"
+                font.capitalization: Font.AllUppercase
+                text: sessionData.weekday_string
+                color: "white"
+            }
         }
 
         /* Add some spacing between the day of week and the calendar graphic */
         Item {
-            height: Kirigami.Units.largeSpacing
+            height: Mycroft.Units.gridUnit / 2
         }
-
+        
         /* Calendar graphic */
-        Image {
-            id: image
-            source: Qt.resolvedUrl("img/date-bg.svg")
-
-            /*  The top part of the calendar graphic containing the month */
-            Image {
-                id: calendartop
-                x: 0
-                width: parent.width
-                fillMode: Image.PreserveAspectFit
-                anchors.top: parent.bottom
-                anchors.topMargin: -(parent.height + 1)
-                source: Qt.resolvedUrl("img/date-top.svg")
-                Label {
-                    id: month
-                    anchors.centerIn: parent
-                    font.pixelSize: 60
-                    wrapMode: Text.WordWrap
-                    font.family: "Noto Sans Display"
-                    font.bold: true
-                    text: sessionData.month_string.split(" ")[0]
-                    color: "white"
+        Item {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: Mycroft.Units.gridUnit * 25.5
+            Layout.preferredHeight: Mycroft.Units.gridUnit * 19.25
+            
+            /* Use Rectangles Instead of Graphics For Proper Scaling of Graphics Items*/
+            Rectangle {
+                id: outterRectangle
+                anchors.fill: parent
+                radius: 30
+                Item {
+                    id: date
+                    anchors.fill: parent
+                    anchors.topMargin: Mycroft.Units.gridUnit * 5.5
+                    
+                    /* The day of the month goes in the calendar graphic under the month */
+                    Label {
+                        anchors.centerIn: parent
+                        font.pixelSize: parent.height
+                        wrapMode: Text.WordWrap
+                        font.family: "Noto Sans Display"
+                        font.styleName: "Bold"
+                        text: sessionData.month_string.split(" ")[1]
+                        color: "#2C3E50"
+                    }
                 }
             }
-
-            /* The day of the month goes in the calendar graphic under the month */
-            Label {
-                id: date
-                anchors.centerIn: parent
-                anchors.verticalCenterOffset: calendartop.height / 2
-                font.pixelSize: 230
-                wrapMode: Text.WordWrap
-                font.family: "Noto Sans Display"
-                font.bold: true
-                text: sessionData.month_string.split(" ")[1]
-                color: "#2C3E50"
+            
+            
+            Item {
+                anchors.fill: outterRectangle
+                layer.enabled: true
+                layer.effect: OpacityMask {
+                    maskSource: outterRectangle
+                }            
+                Rectangle {
+                    id: innerRectangle
+                    width: Mycroft.Units.gridUnit * 25.5
+                    height: Mycroft.Units.gridUnit * 5.5
+                    clip: true
+                    color: "#22A7F0"
+                    
+                    /*  The top part of the calendar graphic containing the month */
+                    Label {
+                        id: month
+                        anchors.centerIn: parent
+                        font.pixelSize: parent.height * 0.65
+                        wrapMode: Text.WordWrap
+                        font.family: "Noto Sans Display"
+                        font.styleName: "Bold"
+                        text: sessionData.month_string.split(" ")[0]
+                        color: "white"
+                    }
+                }
             }
         }
     }

--- a/ui/date.qml
+++ b/ui/date.qml
@@ -37,12 +37,12 @@ Mycroft.CardDelegate {
 
         /* Add some spacing between the day of week and the calendar graphic */
         Item {
-            height: Mycroft.Units.gridUnit / 2
+            Layout.preferredHeight: Mycroft.Units.gridUnit / 2
         }
         
         /* Calendar graphic */
         Item {
-            Layout.alignment: Qt.AlignHCenter
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.preferredWidth: Mycroft.Units.gridUnit * 25.5
             Layout.preferredHeight: Mycroft.Units.gridUnit * 19.25
             

--- a/ui/date.qml
+++ b/ui/date.qml
@@ -63,7 +63,7 @@ Mycroft.CardDelegate {
                         wrapMode: Text.WordWrap
                         font.family: "Noto Sans Display"
                         font.styleName: "Bold"
-                        text: sessionData.month_string.split(" ")[1]
+                        text: sessionData.day_string
                         color: "#2C3E50"
                     }
                 }
@@ -91,7 +91,7 @@ Mycroft.CardDelegate {
                         wrapMode: Text.WordWrap
                         font.family: "Noto Sans Display"
                         font.styleName: "Bold"
-                        text: sessionData.month_string.split(" ")[0]
+                        text: sessionData.month_string
                         color: "white"
                     }
                 }


### PR DESCRIPTION
#### Description
- Date UI ported to Card Delegate
- Use Mycroft gridUnits for graphics
- Use rectangles to draw graphics instead of painting Images, Using fixed svg in layout does not give the same aspect ratio as the Figma
- Fixes text overflow, Text style
 
#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [x] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
 - "What is the current date"


#### CLA
[x] Yes

![date](https://user-images.githubusercontent.com/19663666/116676717-f0965400-a9c4-11eb-8516-e06ea9f5f7c7.png)