### PR TITLE
Make future time intent less greedy

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -451,7 +451,7 @@ class TimeSkill(MycroftSkill):
         self.answering_query = False
         self.displayed_time = None
 
-    @intent_handler(IntentBuilder("future_time_handler_simple").
+    @intent_handler(IntentBuilder("").optionally("Query").
                     require("Time").require("Future").optionally("Location"))
     def handle_future_time_simple(self, message):
         self.handle_query_future_time(message)

--- a/test/behave/time.feature
+++ b/test/behave/time.feature
@@ -99,16 +99,6 @@ Feature: Date Time Skill Time functionality
     | what time will it be in 90 minutes |
     | in 97 minutes what time will it be |
     | what time will it be in 60 seconds |
-
-  @xfail
-  # jira MS-101 https://mycroft.atlassian.net/browse/MS-101
-  Scenario Outline: Failing what's the future time
-    Given an english speaking user
-     When the user says "<what time will it be in 8 hours>"
-     Then "mycroft-date-time" should reply with dialog from "time.future.dialog"
-
-  Examples: what's the future time
-    | what time will it be in 8 hours |
     | what's the time 8 hours from now |
 
   Scenario Outline: what's the future time in a location
@@ -121,16 +111,6 @@ Feature: Date Time Skill Time functionality
      | what time will it be in 8 hours in Berlin |
      | what time will it be 8 hours from now in Paris |
      | what's the time in Los Angeles 8 hours from now |
-
-  @xfail
-  # jira MS-102 https://mycroft.atlassian.net/browse/MS-102
-  Scenario Outline: Failing what's the future time in a location
-    Given an english speaking user
-     When the user says "<what time will it be in the future in a location>"
-     Then "mycroft-date-time" should reply with dialog from "time.future.dialog"
-
-  Examples: what time will it be in the future in a location
-     | what time will it be in the future in a location |
      | give me the time 8 hours from now in Italy |
      | what's the time in France 8 hours |
      | what will be the time in Kansas in 8 hours |

--- a/vocab/en-us/Future.voc
+++ b/vocab/en-us/Future.voc
@@ -1,2 +1,4 @@
-will
 from now
+in
+will be
+will it be

--- a/vocab/en-us/what.time.will.it.be.intent
+++ b/vocab/en-us/what.time.will.it.be.intent
@@ -1,13 +1,2 @@
-what (time will it|will the time) be (in|) {offset} (hours|minutes|seconds) (from now|)
-what (time will it|will the time) be (in|) {offset} (hours|minutes|seconds) (from now|) in {location}
-(what is|what's|what will be) the time in {offset} (hours|minutes|seconds) (from now|)
-(what is|what's|what will be) the time in {offset} (hours|minutes|seconds) (from now|) in {location}
-(give|tell) me the time (in|) {offset} (hours|minutes|seconds) (from now|)
-(give|tell) me the time (in|) {offset} (hours|minutes|seconds) (from now|) in {location}
-(in|) {offset} (hours|minutes|seconds) what (time will it be|will the time be)
-(in|) {offset} (hours|minutes|seconds) (from now|) what (time will it be|will the time be) (at|in|for) {location}
 when is it {offset} (hours|minutes|seconds) (from now|)
 when is it {offset} (hours|minutes|seconds) (from now|) in {location}
-what time (will it be|is it) in {location} (in|) {offset} (hours|minutes|seconds) (from now|)
-(what is|what's|what will be) the time in {location} in {offset} (hours|minutes|seconds) (from now!)
-(at|in|for) {location} what (time will it be|will the time be) (in|) {offset} (hours|minutes|seconds)


### PR DESCRIPTION
#### Description
The Padatious future time intent was so greedy, it was gobbling up some Timer intents.  Trimmed the Padatious intent to just utterances that would not be caught by the Adapt intent for the same purpose.

Requires [mycroft-core PR2947](https://github.com/MycroftAI/mycroft-core/pull/2947) to fix a bug in core regarding how Adapt intents are ranked.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
VK tests should all pass.  All future time requests should respond with the right future time response.

#### Documentation
Changes were to the intents, which are not documented.