### PR TITLE
Update PyTZ for Python 3.10 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytz==2017.2
+pytz==2022.1
 tzlocal==1.3
 timezonefinder
 geocoder


### PR DESCRIPTION
#### Description
The pinned version of PyTZ is failing on Python 3.10.

This updates the PyTZ dependency to provide support for this version of Python.

#### Type of PR
- [x] Bugfix

#### Testing
Voight Kampff integration tests should pass.

#### CLA
- [x] Yes